### PR TITLE
Get all reports/channels of the current logged in user only

### DIFF
--- a/app/controllers/v1/channels_controller.rb
+++ b/app/controllers/v1/channels_controller.rb
@@ -1,5 +1,6 @@
 class V1::ChannelsController < ApplicationController
   before_action :set_channel, only: [:show, :update, :destroy]
+  before_action :channel_user?, except: %i[index new create]
 
   # GET /channels
   def index
@@ -80,5 +81,9 @@ class V1::ChannelsController < ApplicationController
     # Only allow a list of trusted parameters through.
     def channel_params
       params.require(:channel).permit(:title, :description, :category, :user_id)
+    end
+
+    def channel_user?
+      render json: { errors: ['Forbidden access'] }, status: :forbidden if @channel.no_access?(@current_user)
     end
 end

--- a/app/controllers/v1/channels_controller.rb
+++ b/app/controllers/v1/channels_controller.rb
@@ -5,7 +5,7 @@ class V1::ChannelsController < ApplicationController
   def index
     render json: {
       public: Channel.public_channel.order(title: :ASC),
-      personal: Channel.user_personal_channel(params[:user_id]).order(title: :ASC),
+      personal: Channel.user_personal_channel(@current_user).order(title: :ASC),
       group: Channel.group_channel.order(title: :ASC)
     }.to_json(include: :dashboards)
   end

--- a/app/controllers/v1/reports_controller.rb
+++ b/app/controllers/v1/reports_controller.rb
@@ -4,7 +4,7 @@ class V1::ReportsController < ApplicationController
 # GET /reports
   def index
     @public_reports = Report.public_reports.latest
-    @personal_reports = Report.personal_reports(params[:user_id]).latest
+    @personal_reports = Report.personal_reports(@current_user).latest
     @group_reports = Report.group_reports.latest
 
     render json: {

--- a/app/controllers/v1/reports_controller.rb
+++ b/app/controllers/v1/reports_controller.rb
@@ -1,5 +1,6 @@
 class V1::ReportsController < ApplicationController
   before_action :set_report, only: [:show, :update, :destroy]
+  before_action :report_user?, except: %i[index new create]
 
 # GET /reports
   def index
@@ -94,5 +95,9 @@ class V1::ReportsController < ApplicationController
         :last_updated_by,
         tags: []
       )
+    end
+
+    def report_user?
+      render json: { errors: ['Forbidden access'] }, status: :forbidden if @report.no_access?(@current_user)
     end
 end

--- a/app/models/channel.rb
+++ b/app/models/channel.rb
@@ -8,4 +8,8 @@ class Channel < ApplicationRecord
   enum category: %w[group_channel personal_channel public_channel]
 
   scope :user_personal_channel, ->(user_id) { personal_channel.where(user_id: user_id) }
+
+  def no_access?(user)
+    personal_channel? && user_id != user.id
+  end
 end

--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -11,4 +11,8 @@ class Report < ApplicationRecord
   scope :public_reports, -> { joins(:channel).where(channels: { category: 2 }) }
   scope :personal_reports, ->(user_id) { joins(:channel).where(channels: { category: 1 }, user_id: user_id) }
   scope :latest, -> { order('created_at DESC').limit(6) }
+
+  def no_access?(user)
+    channel.personal_channel? && user_id != user.id
+  end
 end


### PR DESCRIPTION
Resolves #6 
No need to pass `user_id` params in `v1/reports` & `v1/channels` as these endpoints will return the personal channels/reports for a logged in user only
![Screenshot 2021-09-28 at 12 39 03 PM](https://user-images.githubusercontent.com/86612095/135129330-0af2cacc-b37b-45bf-9a9a-827ad0f67477.png)

